### PR TITLE
Fix external and glossary urls

### DIFF
--- a/src/09-estudo-de-caso-jogos-de-palavras/00-estudo-de-caso-jogos-de-palavras.md
+++ b/src/09-estudo-de-caso-jogos-de-palavras/00-estudo-de-caso-jogos-de-palavras.md
@@ -1,3 +1,3 @@
 # Capítulo 9: Estudo de caso: jogos de palavras
 
-Este capítulo apresenta o segundo estudo de caso que envolve solucionar quebra-cabeças usando palavras com certas propriedades. Por exemplo, encontraremos os palíndromos mais longos em inglês e procuraremos palavras cujas letras apareçam em ordem alfabética. E apresentarei outro plano de desenvolvimento de programa: a [redução a um problema resolvido anteriormente](06-glossario.md#redução-a um problema resolvido-anteriormente).
+Este capítulo apresenta o segundo estudo de caso que envolve solucionar quebra-cabeças usando palavras com certas propriedades. Por exemplo, encontraremos os palíndromos mais longos em inglês e procuraremos palavras cujas letras apareçam em ordem alfabética. E apresentarei outro plano de desenvolvimento de programa: a [redução a um problema resolvido anteriormente](06-glossario.md#redução-a-um-problema-resolvido-anteriormente).

--- a/src/09-estudo-de-caso-jogos-de-palavras/07-exercicios.md
+++ b/src/09-estudo-de-caso-jogos-de-palavras/07-exercicios.md
@@ -2,7 +2,7 @@
 
 ### Exercício 9.7
 
-Esta pergunta é baseada em um quebra-cabeça veiculado em um programa de rádio chamado Car Talk (http://www.cartalk.com/content/puzzlers):
+Esta pergunta é baseada em um quebra-cabeça veiculado em um programa de rádio chamado Car Talk (<http://www.cartalk.com/content/puzzlers>):
 
 Dê uma palavra com três letras duplas consecutivas. Vou dar exemplos de palavras que quase cumprem a condição, mas não chegam lá. Por exemplo, a palavra committee, c-o-m-m-i-t-t-e-e. Seria perfeita se não fosse aquele ‘i’ que se meteu ali no meio. Ou Mississippi: M-i-s-s-i-s-s-i-p-p-i. Se pudesse tirar aqueles ‘is’, daria certo. Mas há uma palavra que tem três pares consecutivos de letras e, que eu saiba, pode ser a única palavra que existe. É claro que provavelmente haja mais umas 500, mas só consigo pensar nessa. Qual é a palavra?
 
@@ -12,7 +12,7 @@ Solução: [http://thinkpython2.com/code/cartalk1.py](http://thinkpython2.com/co
 
 ### Exercício 9.8
 
-Aqui está outro quebra-cabeça do programa Car Talk (http://www.cartalk.com/content/puzzlers):
+Aqui está outro quebra-cabeça do programa Car Talk (<http://www.cartalk.com/content/puzzlers>):
 
 “Estava dirigindo outro dia e percebi algo no hodômetro que chamou a minha atenção. Como a maior parte dos hodômetros, ele mostra seis dígitos, apenas em milhas inteiras. Por exemplo, se o meu carro tivesse 300.000 milhas, eu veria 3-0-0-0-0-0.
 
@@ -28,7 +28,7 @@ Solução: [http://thinkpython2.com/code/cartalk2.py](http://thinkpython2.com/co
 
 ### Exercício 9.9
 
-Aqui está outro problema do Car Talk que você pode resolver com uma busca (http://www.cartalk.com/content/puzzlers):
+Aqui está outro problema do Car Talk que você pode resolver com uma busca (<http://www.cartalk.com/content/puzzlers>):
 
 “Há pouco tempo recebi uma visita da minha mãe e percebemos que os dois dígitos que compõem a minha idade, quando invertidos, representavam a idade dela. Por exemplo, se ela tem 73 anos, eu tenho 37 anos. Ficamos imaginando com que frequência isto aconteceu nos anos anteriores, mas acabamos mudando de assunto e não chegamos a uma resposta.
 

--- a/src/11-dicionarios/10-exercicios.md
+++ b/src/11-dicionarios/10-exercicios.md
@@ -36,7 +36,7 @@ Solução: [http://thinkpython2.com/code/rotate_pairs.py](http://thinkpython2.co
 
 ### Exercício 11.6
 
-Aqui está outro quebra-cabeça do programa Car Talk (http://www.cartalk.com/content/puzzlers):
+Aqui está outro quebra-cabeça do programa Car Talk (<http://www.cartalk.com/content/puzzlers>):
 
 Ele foi enviado por Dan O’Leary. Dan descobriu uma palavra comum, com uma sílaba e cinco letras que tem a seguinte propriedade única. Ao removermos a primeira letra, as letras restantes formam um homófono da palavra original, que é uma palavra que soa exatamente da mesma forma. Substitua a primeira letra, isto é, coloque-a de volta, retire a segunda letra e o resultado é um outro homófono da palavra original. E a pergunta é, qual é a palavra?
 

--- a/src/12-tuplas/10-exercicios.md
+++ b/src/12-tuplas/10-exercicios.md
@@ -37,7 +37,7 @@ Solução: [http://thinkpython2.com/code/metathesis.py](http://thinkpython2.com/
 
 ### Exercício 12.4
 
-Aqui está outro quebra-cabeça do programa Car Talk (http://www.cartalk.com/content/puzzlers):
+Aqui está outro quebra-cabeça do programa Car Talk (<http://www.cartalk.com/content/puzzlers>):
 
 Qual é a palavra inglesa mais longa, que permanece uma palavra inglesa válida, conforme vai removendo suas letras, uma após a outra?
 

--- a/src/13-estudo-de-caso-selecao-de-estrutura-de-dados/01-analise-de-frequencia-de-palavras.md
+++ b/src/13-estudo-de-caso-selecao-de-estrutura-de-dados/01-analise-de-frequencia-de-palavras.md
@@ -18,7 +18,7 @@ Além disso, você pode usar os métodos de string, strip, replace e translate.
 
 ### Exercício 13.2
 
-Acesse o Projeto Gutenberg (http://gutenberg.org) e baixe seu livro favorito em domínio público em formato de texto simples.
+Acesse o Projeto Gutenberg (<https://gutenberg.org>) e baixe seu livro favorito em domínio público em formato de texto simples.
 
 Altere seu programa do exercício anterior para ler o livro que você baixou, pulando as informações do cabeçalho no início do arquivo e processando o resto das palavras como antes.
 

--- a/src/13-estudo-de-caso-selecao-de-estrutura-de-dados/10-depuracao.md
+++ b/src/13-estudo-de-caso-selecao-de-estrutura-de-dados/10-depuracao.md
@@ -18,7 +18,7 @@ Quando estiver depurando um programa, especialmente se estiver trabalhando em um
 
 ##### Conversa com o pato de borracha (rubberducking)
 
-  &nbsp;&nbsp;&nbsp;&nbsp;Ao explicar o problema a alguém, às vezes você consegue encontrar a resposta antes de terminar a explicação. Muitas vezes, não é preciso nem haver outra pessoa; você pode falar até com um pato de borracha. E essa é a origem de uma estratégia bem conhecida chamada de [depuração do pato de borracha](11-glossario.md#depuração-do pato de-borracha). Não estou inventando isso, veja [https://en.wikipedia.org/wiki/Rubber_duck_debugging.</dd>](https://en.wikipedia.org/wiki/Rubber_duck_debugging.)
+  &nbsp;&nbsp;&nbsp;&nbsp;Ao explicar o problema a alguém, às vezes você consegue encontrar a resposta antes de terminar a explicação. Muitas vezes, não é preciso nem haver outra pessoa; você pode falar até com um pato de borracha. E essa é a origem de uma estratégia bem conhecida chamada de [depuração do pato de borracha](11-glossario.md#depuração-do-pato-de-borracha). Não estou inventando isso, veja [https://en.wikipedia.org/wiki/Rubber_duck_debugging.</dd>](https://en.wikipedia.org/wiki/Rubber_duck_debugging.)
 
 ##### Retirada
 

--- a/src/17-classes-e-metodos/01-recursos-de-orientacao-a-objeto.md
+++ b/src/17-classes-e-metodos/01-recursos-de-orientacao-a-objeto.md
@@ -1,6 +1,6 @@
 ## 17.1 - Recursos de orientação a objeto
 
-Python é uma linguagem de [programação orientada a objeto](12-glossario.md#programação-orientada a-objeto), ou seja, ela oferece recursos de programação orientada a objeto que tem a seguintes características:
+Python é uma linguagem de [programação orientada a objeto](12-glossario.md#programação-orientada-a-objeto), ou seja, ela oferece recursos de programação orientada a objeto que tem a seguintes características:
 
 * Os programas incluem definições de classes e métodos.
 

--- a/src/apendice-b-analise-de-algoritmos.md
+++ b/src/apendice-b-analise-de-algoritmos.md
@@ -8,7 +8,7 @@ A meta prática da análise de algoritmos é prever o desempenho de algoritmos d
 
 Durante a campanha presidencial dos Estados Unidos de 2008, pediram ao candidato Barack Obama para fazer uma entrevista de emprego improvisada quando visitou a Google. O diretor executivo, Eric Schmidt, brincou, pedindo a ele “a forma mais eficiente de classificar um milhão de números inteiros de 32 bits”. Aparentemente, Obama tinha sido alertado porque respondeu na hora: “Creio que a ordenação por bolha (bubble sort) não seria a escolha certa”. Veja [http://bit.ly/1MpIwTf](http://bit.ly/1MpIwTf).
 
-Isso é verdade: a ordenação por bolha é conceitualmente simples, mas lenta para grandes conjuntos de dados. A resposta que Schmidt procurava provavelmente é “ordenação radix” (radix sort) (http://en.wikipedia.org/wiki/Radix_sort)[2].
+Isso é verdade: a ordenação por bolha é conceitualmente simples, mas lenta para grandes conjuntos de dados. A resposta que Schmidt procurava provavelmente é “ordenação radix” [(radix sort)](http://en.wikipedia.org/wiki/Radix_sort)[2].
 
 A meta da análise de algoritmos é fazer comparações significativas entre algoritmos, mas há alguns problemas:
 


### PR DESCRIPTION
- Some glossary URLs had spaces instead of hyphens (e.g. `#a-long url-to-glossary` instead of `#a-long-url-to-glossary`);
- Surrounded "bare" URLs with `<>`, so they could link to the same URL as their string (e.g. replace `(https://website.com)` with `(<https://website.com>)`, so it becomes "(<https://website.com>)" instead of just plain text).