### PR TITLE
[Fixes #9] Fix misspell: endentado -> indentado.

### DIFF
--- a/src/03-funcoes/04-como-acrescentar-novas-funcoes.md
+++ b/src/03-funcoes/04-como-acrescentar-novas-funcoes.md
@@ -14,7 +14,7 @@ def print_lyrics():
 
 Os parênteses vazios depois do nome indicam que esta função não usa argumentos.
 
-A primeira linha da definição de função chama-se [cabeçalho](13-glossario.md#cabeçalho); o resto é chamado de [corpo](13-glossario.md#corpo). O cabeçalho precisa terminar em dois pontos e o corpo precisa ser endentado. Por convenção, a endentação sempre é de quatro espaços. O corpo pode conter qualquer número de instruções.
+A primeira linha da definição de função chama-se [cabeçalho](13-glossario.md#cabeçalho); o resto é chamado de [corpo](13-glossario.md#corpo). O cabeçalho precisa terminar em dois pontos e o corpo precisa ser indentado. Por convenção, a endentação sempre é de quatro espaços. O corpo pode conter qualquer número de instruções.
 
 As strings nas instruções de exibição são limitadas por aspas duplas. As aspas simples e as aspas duplas fazem a mesma coisa; a maior parte das pessoas usa aspas simples apenas nos casos em que aspas simples (que também são apóstrofes) aparecem na string.
 

--- a/src/04-estudo-de-caso-projeto-de-interface/02-repeticao-simples.md
+++ b/src/04-estudo-de-caso-projeto-de-interface/02-repeticao-simples.md
@@ -39,7 +39,7 @@ for i in range(4):
     bob.lt(90)
 ```
 
-A sintaxe de uma instrução for é semelhante à definição de uma função. Tem um cabeçalho que termina em dois pontos e um corpo endentado. O corpo pode conter qualquer número de instruções.
+A sintaxe de uma instrução for é semelhante à definição de uma função. Tem um cabeçalho que termina em dois pontos e um corpo indentado. O corpo pode conter qualquer número de instruções.
 
 Uma instrução for também é chamada de [loop](11-glossario.md#loop) porque o fluxo da execução passa pelo corpo e depois volta ao topo. Neste caso, ele passa pelo corpo quatro vezes.
 

--- a/src/05-condicionais-e-recursividade/04-execucao-condicional.md
+++ b/src/05-condicionais-e-recursividade/04-execucao-condicional.md
@@ -9,7 +9,7 @@ if x > 0:
 
 A [expressão booleana](13-glossario.md#expressão-booleana) depois do if é chamada de [condição](13-glossario.md#condição). Se for verdadeira, a instrução endentada é executada. Se não, nada acontece.
 
-Instruções if têm a mesma estrutura que definições de função: um cabeçalho seguido de um corpo endentado. Instruções como essa são chamadas de instruções compostas.
+Instruções if têm a mesma estrutura que definições de função: um cabeçalho seguido de um corpo indentado. Instruções como essa são chamadas de instruções compostas.
 
 Não há limite para o número de instruções que podem aparecer no corpo, mas deve haver pelo menos uma. Ocasionalmente, é útil ter um corpo sem instruções (normalmente como um espaço reservado para código que ainda não foi escrito). Neste caso, você pode usar a instrução pass, que não faz nada.
 

--- a/src/05-condicionais-e-recursividade/13-glossario.md
+++ b/src/05-condicionais-e-recursividade/13-glossario.md
@@ -23,7 +23,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp;A expressão booleana em uma instrução condicional que determina qual ramo deve ser executado.
 
 ##### instrução composta
-&nbsp;&nbsp;&nbsp;&nbsp;Uma instrução composta de um cabeçalho e um corpo. O cabeçalho termina em dois pontos (:). O corpo é endentado em relação ao cabeçalho.
+&nbsp;&nbsp;&nbsp;&nbsp;Uma instrução composta de um cabeçalho e um corpo. O cabeçalho termina em dois pontos (:). O corpo é indentado em relação ao cabeçalho.
 
 ##### ramo
 &nbsp;&nbsp;&nbsp;&nbsp;Uma das sequências alternativas de instruções em uma instrução condicional.


### PR DESCRIPTION
"Indentado" estava escrito errado ("endentado"), foi corrigido nesse PR.